### PR TITLE
Added collect_in_leaf to handle leaf types in sid-extension

### DIFF
--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -735,24 +735,7 @@ class SidFile:
     def collect_inner_data_nodes(self, statements, prefix=""):
         for statement in statements:
             if statement.keyword in self.leaf_keywords:
-                if self.sid_extension:
-                    for s in statement.substmts: # find type declaration
-                        if s.keyword == "type":
-                            if s.i_type_spec.name == "identityref":
-                                typename = "identityref"
-
-                            elif s.i_type_spec.name == "enumeration":
-                                typename = {}
-                                for k, v in s.i_type_spec.enums:
-                                    typename[str(v)] = k
-                            else:
-                                typename = s.arg
-
-                            if typename=="union": # union put all types in an array
-                                typename = []
-                                for t in s.i_type_spec.types:
-                                    typename.append(t.arg)
-                self.merge_item('data', self.get_path(statement, prefix), typename if self.sid_extension else None)
+                self.collect_in_leaf(statement)
 
             elif statement.keyword in self.container_keywords:
                 self.merge_item('data', self.get_path(statement, prefix))
@@ -789,24 +772,7 @@ class SidFile:
     def collect_in_substmts(self, substmts):
         for statement in substmts:
             if statement.keyword in self.leaf_keywords:
-                if self.sid_extension:
-                    for s in statement.substmts: # find type declaration
-                        if s.keyword == "type":
-                            if s.i_type_spec.name == "identityref":
-                                typename = "identityref"
-
-                            elif s.i_type_spec.name == "enumeration":
-                                typename = {}
-                                for k, v in s.i_type_spec.enums:
-                                    typename[str(v)] = k
-                            else:
-                                typename = s.arg
-
-                            if typename=="union": # union put all types in an array
-                                typename = []
-                                for t in s.i_type_spec.types:
-                                    typename.append(t.arg)
-                self.merge_item('data', self.get_path(statement), typename if self.sid_extension else None)
+                self.collect_in_leaf(statement)
 
             elif (statement.keyword in self.container_keywords or
                   statement.keyword in self.choice_keywords):
@@ -817,6 +783,26 @@ class SidFile:
                 prefix = self.get_path(statement.parent)
                 self.collect_inner_data_nodes(statement.i_grouping.i_children,
                                               prefix)
+
+    def collect_in_leaf(self, statement):
+        if self.sid_extension:
+            for s in statement.substmts: # find type declaration
+                if s.keyword == "type":
+                    if s.i_type_spec.name == "identityref":
+                        typename = "identityref"
+
+                    elif s.i_type_spec.name == "enumeration":
+                        typename = {}
+                        for k, v in s.i_type_spec.enums:
+                            typename[str(v)] = k
+                    else:
+                        typename = s.arg
+
+                    if typename=="union": # union put all types in an array
+                        typename = []
+                        for t in s.i_type_spec.types:
+                            typename.append(t.arg)
+        self.merge_item('data', self.get_path(statement), typename if self.sid_extension else None)
 
     def get_path(self, statement, prefix=""):
         path = ""

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -789,7 +789,24 @@ class SidFile:
     def collect_in_substmts(self, substmts):
         for statement in substmts:
             if statement.keyword in self.leaf_keywords:
-                self.merge_item('data', self.get_path(statement))
+                if self.sid_extension:
+                    for s in statement.substmts: # find type declaration
+                        if s.keyword == "type":
+                            if s.i_type_spec.name == "identityref":
+                                typename = "identityref"
+
+                            elif s.i_type_spec.name == "enumeration":
+                                typename = {}
+                                for k, v in s.i_type_spec.enums:
+                                    typename[str(v)] = k
+                            else:
+                                typename = s.arg
+
+                            if typename=="union": # union put all types in an array
+                                typename = []
+                                for t in s.i_type_spec.types:
+                                    typename.append(t.arg)
+                self.merge_item('data', self.get_path(statement), typename if self.sid_extension else None)
 
             elif (statement.keyword in self.container_keywords or
                   statement.keyword in self.choice_keywords):


### PR DESCRIPTION
Hi, 

I know this is still a work in progress, but I was using this branch for a test with a switch I have that supports CORECONF. When I tried to generate the .sid file for `ietf-ip.yang`, the type was not being added to leaf nodes. I traced it to what seems to be a need to have similar logic in `collect_in_substmts()` that already exists in `collect_inner_data_nodes()`. So I added a helper function that does this. 

BEFORE this modification:
```
> pyang --sid-generate-file 9000:1000 --sid-list --sid-extension ietf-ip.yang
> cat ietf-ip@2018-02-22.sid
...
      {
        "namespace": "data",
        "identifier": "/ietf-interfaces:interfaces-state/interface/ietf-ip:ipv4/address/prefix-length",
        "status": "unstable",
        "sid": "9008"
      },
...
```

AFTER this modification:
```
> pyang --sid-generate-file 9000:1000 --sid-list --sid-extension ietf-ip.yang
> cat ietf-ip@2018-02-22.sid
...
      {
        "namespace": "data",
        "identifier": "/ietf-interfaces:interfaces-state/interface/ietf-ip:ipv4/address/prefix-length",
        "status": "unstable",
        "sid": "9008",
        "type": "uint8"
      },
...
```