### PR TITLE
Sid extension add key mapping validation

### DIFF
--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -55,6 +55,10 @@ class SidPlugin(plugin.PyangPlugin):
                          action="store_true",
                          dest="list_sid",
                          help="Print the list of SID."),
+            optparse.make_option("--sid-extension",
+                         action="store_true",
+                         dest="sid_ext",
+                         help="Add info to the sid file to manipulate CORECONF."),
             optparse.make_option("--sid-finalize",
                          action="store_true",
                          dest="finalize_sid",
@@ -138,6 +142,9 @@ class SidPlugin(plugin.PyangPlugin):
 
         if ctx.opts.list_sid:
             sid_file.list_content = True
+
+        if ctx.opts.sid_ext:
+            sid_file.sid_extension = True
 
         if ctx.opts.finalize_sid:
             print("Will mark unstable allocations finalized")
@@ -240,6 +247,13 @@ OPTIONS
   obtains the list of SIDs assigned or validated. For example:
 
   $ pyang --sid-list --sid-generate-file 20000:100 toaster@2009-11-20.yang
+          
+--sid-extension
+
+   Add non standard entries in the .sid file to facilitate CORECONF manipulation
+   on constrained devices. 
+
+  $ pyang --sid-list --sid-generate-file 20000:100 --sid-extension toaster@2009-11-20.yang
 
 --sid-finalize
 
@@ -309,6 +323,7 @@ class SidFile:
         self.module_revision = ''
         self.output_file_name = ''
         self.update = False
+        self.sid_extension = False
 
     def process_sid_file(self, module):
         self.module_name = module.i_modulename
@@ -664,6 +679,9 @@ class SidFile:
         if 'item' not in self.content:
             self.content['item'] = []
 
+        if self.sid_extension and 'key-mapping' not in self.content: 
+            self.content['key-mapping'] = {}
+
         for item in self.content['item']:
             # Set to 'd' deleted, updated to 'o' if present in .yang file
             item['lifecycle'] = 'd'
@@ -717,10 +735,37 @@ class SidFile:
     def collect_inner_data_nodes(self, statements, prefix=""):
         for statement in statements:
             if statement.keyword in self.leaf_keywords:
-                self.merge_item('data', self.get_path(statement, prefix))
+                if self.sid_extension:
+                    for s in statement.substmts: # find type declaration
+                        print (s)
+                        if s.keyword == "type":
+                            if s.i_type_spec.name == "identityref":
+                                typename = "identityref"
+
+                            elif s.i_type_spec.name == "enumeration":
+                                typename = {}
+                                for k, v in s.i_type_spec.enums:
+                                    typename[str(v)] = k
+                            else:
+                                typename = s.arg
+
+                            if typename=="union": # union put all types in an array
+                                typename = []
+                                for t in s.i_type_spec.types:
+                                    typename.append(t.arg)
+                self.merge_item('data', self.get_path(statement, prefix), typename if self.sid_extension else None)
 
             elif statement.keyword in self.container_keywords:
                 self.merge_item('data', self.get_path(statement, prefix))
+                if self.sid_extension: # create key-mapping for list, with the path of the keys as value
+                    if statement.keyword == "list":
+                        keys = []
+        
+                        if hasattr(statement, 'i_key') and statement.i_key:
+                            for k in statement.i_key:
+                                keys.append(self.get_path(k, prefix))
+        
+                        self.content["key-mapping"][self.get_path(statement, prefix)] = keys
                 self.collect_inner_data_nodes(statement.i_children, prefix)
 
             elif statement.keyword in self.choice_keywords:
@@ -792,16 +837,23 @@ class SidFile:
             statement = statement.parent
         return prefix + path
 
-    def merge_item(self, namespace, identifier):
+    def merge_item(self, namespace, identifier, typename=None):
         for item in self.content['item']:
             if (namespace == item['namespace'] and
                     identifier == item['identifier']):
                 item['lifecycle'] = 'o' # Item already assigned
                 return
-        self.content['item'].append(collections.OrderedDict(
-            [('namespace', namespace), ('identifier', identifier),
-             ('status', 'unstable'),
-             ('sid', -1), ('lifecycle', 'n')]))
+            
+        if self.sid_extension and typename is not None:
+            self.content['item'].append(collections.OrderedDict(
+                [('namespace', namespace), ('identifier', identifier),
+                 ('status', 'unstable'),
+                 ('sid', -1), ('lifecycle', 'n'), ('type', typename)]))
+        else:   
+            self.content['item'].append(collections.OrderedDict(
+                [('namespace', namespace), ('identifier', identifier),
+                ('status', 'unstable'),
+                ('sid', -1), ('lifecycle', 'n')]))
         self.is_consistent = False
 
     ########################################################
@@ -973,6 +1025,14 @@ class SidFile:
                   "with a 'deprecated' or 'obsolete' status.")
 
     ########################################################
+
+    def find_sid(self, id):
+        for e in self.content['item']:
+            if e['identifier'] == id:
+                return e['sid']
+        return None
+
+
     def generate_file(self):
         for item in self.content['item']:
             del item['lifecycle']
@@ -1020,6 +1080,18 @@ class SidFile:
                     print("  finalized %s" % (item['identifier']))
                     # status 'stable' is default enum
                     del item['status']
+
+        if self.sid_extension:
+            key_mapping_sid = {}
+            for k, v in self.content['key-mapping'].items():
+                k_sid = self.find_sid(k)
+                v_sids = []
+                for e in v:
+                    v_sids.append(self.find_sid(e))
+                key_mapping_sid[k_sid] = v_sids
+
+            sid_cont['key-mapping'] = key_mapping_sid
+
 
         with open(self.output_file_name, 'w') as outfile:
             outfile.truncate(0)

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -800,6 +800,7 @@ class SidFile:
 
                     if typename=="union": # union put all types in an array
                         typename = []
+                        print ("UNION type found for %s, collecting types in an array" % self.get_path(statement))
                         for t in s.i_type_spec.types:
                             if s.i_type_spec.name == "identityref":
                                 typename.append("identityref")

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -802,7 +802,7 @@ class SidFile:
                         typename = []
                         for t in s.i_type_spec.types:
                             if t.i_type_spec.name == "identityref":
-                                typename.append("identityref")
+                                typename.insert(0, "identityref") # put identityref first in the list as it is more specific than other types
                             else:
                                 typename.append(t.arg)
         self.merge_item('data', self.get_path(statement), typename if self.sid_extension else None)

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -519,6 +519,11 @@ class SidFile:
                     raise SidFileError("key 'item', invalid value.")
                 self.validate_items(self.content[key])
 
+            elif key == 'key-mapping':
+                if not isinstance(self.content[key], dict):
+                    raise SidFileError("key 'key-mapping', invalid value.")
+                self.validate_key_mapping(self.content[key])
+
             else:
                 raise SidFileError("invalid field '%s'." % key)
 
@@ -615,6 +620,10 @@ class SidFile:
 
             if sid_absent:
                 raise SidFileError("mandatory field 'sid' not present")
+
+    def validate_key_mapping(self, key_mapping):
+        # TODO: This is empty for now, but it should validate these mappings
+        return
 
     ########################################################
     # Verify if each range defined in the .sid file is distinct

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -737,7 +737,6 @@ class SidFile:
             if statement.keyword in self.leaf_keywords:
                 if self.sid_extension:
                     for s in statement.substmts: # find type declaration
-                        print (s)
                         if s.keyword == "type":
                             if s.i_type_spec.name == "identityref":
                                 typename = "identityref"

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -800,7 +800,7 @@ class SidFile:
 
                     if typename=="union": # union put all types in an array
                         typename = []
-                        print ("UNION type found for %s, collecting types in an array" % self.get_path(statement))
+                        print ("UNION type found for %s, collecting types in an array" % s.i_type_spec.name)
                         for t in s.i_type_spec.types:
                             if s.i_type_spec.name == "identityref":
                                 typename.append("identityref")

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -801,7 +801,10 @@ class SidFile:
                     if typename=="union": # union put all types in an array
                         typename = []
                         for t in s.i_type_spec.types:
-                            typename.append(t.arg)
+                            if s.i_type_spec.name == "identityref":
+                                typename.append("identityref")
+                            else:
+                                typename.append(t.arg)
         self.merge_item('data', self.get_path(statement), typename if self.sid_extension else None)
 
     def get_path(self, statement, prefix=""):

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -622,8 +622,42 @@ class SidFile:
                 raise SidFileError("mandatory field 'sid' not present")
 
     def validate_key_mapping(self, key_mapping):
-        # TODO: This is empty for now, but it should validate these mappings
-        return
+        """Validate key-mapping structure.
+
+        key-mapping maps list SIDs to arrays of their key field SIDs.
+        Format: {"list_sid": [key1_sid, key2_sid, ...], ...}
+        """
+        for key, value in key_mapping.items():
+            # Validate key is a string representation of an integer (SID)
+            if not isinstance(key, str):
+                raise SidFileError(
+                    "key-mapping key must be a string, got '%s'." % type(key).__name__)
+
+            try:
+                key_sid = int(key)
+                if key_sid <= 0:
+                    raise ValueError
+            except (ValueError, TypeError):
+                raise SidFileError(
+                    "key-mapping key '%s' must be a positive integer." % key)
+
+            # Validate value is a list/array
+            if not isinstance(value, list):
+                raise SidFileError(
+                    "key-mapping value for key '%s' must be a list, got '%s'."
+                    % (key, type(value).__name__))
+
+            # Validate each element in the list is a positive integer (SID)
+            for idx, element in enumerate(value):
+                if not isinstance(element, util.int_types):
+                    raise SidFileError(
+                        "key-mapping value for key '%s' at index %d must be an integer, got '%s'."
+                        % (key, idx, type(element).__name__))
+
+                if element <= 0:
+                    raise SidFileError(
+                        "key-mapping value for key '%s' at index %d must be a positive integer, got %d."
+                        % (key, idx, element))
 
     ########################################################
     # Verify if each range defined in the .sid file is distinct

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -735,24 +735,7 @@ class SidFile:
     def collect_inner_data_nodes(self, statements, prefix=""):
         for statement in statements:
             if statement.keyword in self.leaf_keywords:
-                if self.sid_extension:
-                    for s in statement.substmts: # find type declaration
-                        if s.keyword == "type":
-                            if s.i_type_spec.name == "identityref":
-                                typename = "identityref"
-
-                            elif s.i_type_spec.name == "enumeration":
-                                typename = {}
-                                for k, v in s.i_type_spec.enums:
-                                    typename[str(v)] = k
-                            else:
-                                typename = s.arg
-
-                            if typename=="union": # union put all types in an array
-                                typename = []
-                                for t in s.i_type_spec.types:
-                                    typename.append(t.arg)
-                self.merge_item('data', self.get_path(statement, prefix), typename if self.sid_extension else None)
+                self.collect_in_leaf(statement)
 
             elif statement.keyword in self.container_keywords:
                 self.merge_item('data', self.get_path(statement, prefix))
@@ -789,24 +772,7 @@ class SidFile:
     def collect_in_substmts(self, substmts):
         for statement in substmts:
             if statement.keyword in self.leaf_keywords:
-                if self.sid_extension:
-                    for s in statement.substmts: # find type declaration
-                        if s.keyword == "type":
-                            if s.i_type_spec.name == "identityref":
-                                typename = "identityref"
-
-                            elif s.i_type_spec.name == "enumeration":
-                                typename = {}
-                                for k, v in s.i_type_spec.enums:
-                                    typename[str(v)] = k
-                            else:
-                                typename = s.arg
-
-                            if typename=="union": # union put all types in an array
-                                typename = []
-                                for t in s.i_type_spec.types:
-                                    typename.append(t.arg)
-                self.merge_item('data', self.get_path(statement), typename if self.sid_extension else None)
+                self.collect_in_leaf(statement)
 
             elif (statement.keyword in self.container_keywords or
                   statement.keyword in self.choice_keywords):
@@ -817,6 +783,26 @@ class SidFile:
                 prefix = self.get_path(statement.parent)
                 self.collect_inner_data_nodes(statement.i_grouping.i_children,
                                               prefix)
+
+    def collect_in_leaf(self, statement):
+        if self.sid_extension:
+            for s in statement.substmts: # find type declaration
+                if s.keyword == "type":
+                    if s.i_type_spec.name == "identityref":
+                        typename = "identityref"
+
+                    elif s.i_type_spec.name == "enumeration":
+                        typename = {}
+                        for k, v in s.i_type_spec.enums:
+                            typename[str(v)] = k
+                    else:
+                        typename = s.arg
+
+                    if typename=="union": # union put all types in an array
+                        typename = []
+                        for t in s.i_type_spec.types:
+                            typename.append(t.arg)
+        self.merge_item('data', self.get_path(statement), typename if self.sid_extension else None)
 
     def get_path(self, statement, prefix=""):
         path = ""

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -800,9 +800,8 @@ class SidFile:
 
                     if typename=="union": # union put all types in an array
                         typename = []
-                        print ("UNION type found for %s, collecting types in an array" % s.i_type_spec.name)
                         for t in s.i_type_spec.types:
-                            if s.i_type_spec.name == "identityref":
+                            if t.i_type_spec.name == "identityref":
                                 typename.append("identityref")
                             else:
                                 typename.append(t.arg)

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -789,7 +789,24 @@ class SidFile:
     def collect_in_substmts(self, substmts):
         for statement in substmts:
             if statement.keyword in self.leaf_keywords:
-                self.merge_item('data', self.get_path(statement))
+                if self.sid_extension:
+                    for s in statement.substmts: # find type declaration
+                        if s.keyword == "type":
+                            if s.i_type_spec.name == "identityref":
+                                typename = "identityref"
+
+                            elif s.i_type_spec.name == "enumeration":
+                                typename = {}
+                                for k, v in s.i_type_spec.enums:
+                                    typename[str(v)] = k
+                            else:
+                                typename = s.arg
+
+                            if typename=="union": # union put all types in an array
+                                typename = []
+                                for t in s.i_type_spec.types:
+                                    typename.append(t.arg)
+                self.merge_item('data', self.get_path(statement), typename if self.sid_extension else None)
 
             elif (statement.keyword in self.container_keywords or
                   statement.keyword in self.choice_keywords):

--- a/test/test_sid/Makefile
+++ b/test/test_sid/Makefile
@@ -2,10 +2,12 @@ PYANG?= pyang
 
 .PHONY: test test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 \
 	test12 test14 test15 test16 test17 test18 test19 test20 test21 test22 test23 \
-	test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34
+	test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34 \
+	test35 test36 test37 test38
 test: test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 \
 	test12 test14 test15 test16 test17 test18 test19 test20 test21 test22 \
-	test23 test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34
+	test23 test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34 \
+	test35 test36 test37 test38
 
 test1:
 	# Test help
@@ -195,4 +197,22 @@ test34: aug-a@2025-08-25.yang aug-b@2025-08-25.yang aug-c@2025-08-25.yang test-3
 	$(PYANG) --sid-generate-file 1200:100 aug-c@2025-08-25.yang --sid-finalize >/dev/null 2>/dev/null
 	diff -b aug-c@2025-08-25.sid test-34-expected-aug-c.sid
 	rm aug-a@2025-08-25.sid aug-b@2025-08-25.sid aug-c@2025-08-25.sid
+
+test35: test-with-key-mapping.yang test-35-expected-output.txt test-35-expected-test-with-key-mapping@2026-04-16.sid
+	# Test key-mapping generation with --sid-extension
+	$(PYANG) --sid-generate-file 40000:20 --sid-extension test-with-key-mapping.yang 2>&1 | diff -b test-35-expected-output.txt -
+	diff -b test-with-key-mapping@2026-04-16.sid test-35-expected-test-with-key-mapping@2026-04-16.sid
+	rm test-with-key-mapping@2026-04-16.sid
+
+test36: test36-bad-key-mapping.sid test-with-key-mapping.yang test-36-expected-output.txt
+	# Test key-mapping validation: value must be a list
+	$(PYANG) --sid-check-file test36-bad-key-mapping.sid test-with-key-mapping.yang 2>&1 | diff -b test-36-expected-output.txt -
+
+test37: test37-bad-key-mapping.sid test-with-key-mapping.yang test-37-expected-output.txt
+	# Test key-mapping validation: list elements must be integers
+	$(PYANG) --sid-check-file test37-bad-key-mapping.sid test-with-key-mapping.yang 2>&1 | diff -b test-37-expected-output.txt -
+
+test38: test38-bad-key-mapping.sid test-with-key-mapping.yang test-38-expected-output.txt
+	# Test key-mapping validation: list elements must be positive integers
+	$(PYANG) --sid-check-file test38-bad-key-mapping.sid test-with-key-mapping.yang 2>&1 | diff -b test-38-expected-output.txt -
 

--- a/test/test_sid/test-35-expected-output.txt
+++ b/test/test_sid/test-35-expected-output.txt
@@ -1,0 +1,4 @@
+
+File test-with-key-mapping@2026-04-16.sid created
+Number of SIDs available : 20
+Number of SIDs used : 9

--- a/test/test_sid/test-35-expected-test-with-key-mapping@2026-04-16.sid
+++ b/test/test_sid/test-35-expected-test-with-key-mapping@2026-04-16.sid
@@ -1,0 +1,83 @@
+{
+  "ietf-sid-file:sid-file": {
+    "module-name": "test-with-key-mapping",
+    "module-revision": "2026-04-16",
+    "sid-file-status": "unpublished",
+    "assignment-range": [
+      {
+        "entry-point": "40000",
+        "size": "20"
+      }
+    ],
+    "item": [
+      {
+        "namespace": "module",
+        "identifier": "test-with-key-mapping",
+        "status": "unstable",
+        "sid": "40000"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/test-with-key-mapping:devices",
+        "status": "unstable",
+        "sid": "40001"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/test-with-key-mapping:devices/device",
+        "status": "unstable",
+        "sid": "40002"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/test-with-key-mapping:devices/device/device-id",
+        "status": "unstable",
+        "sid": "40003",
+        "type": "uint32"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/test-with-key-mapping:devices/device/name",
+        "status": "unstable",
+        "sid": "40004",
+        "type": "string"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/test-with-key-mapping:devices/interface",
+        "status": "unstable",
+        "sid": "40005"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/test-with-key-mapping:devices/interface/if-name",
+        "status": "unstable",
+        "sid": "40006",
+        "type": "string"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/test-with-key-mapping:devices/interface/if-type",
+        "status": "unstable",
+        "sid": "40007",
+        "type": "string"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/test-with-key-mapping:devices/interface/status",
+        "status": "unstable",
+        "sid": "40008",
+        "type": "string"
+      }
+    ],
+    "key-mapping": {
+      "40002": [
+        40003
+      ],
+      "40005": [
+        40006,
+        40007
+      ]
+    }
+  }
+}

--- a/test/test_sid/test-36-expected-output.txt
+++ b/test/test_sid/test-36-expected-output.txt
@@ -1,0 +1,2 @@
+ERROR in 'test36-bad-key-mapping.sid', key-mapping value for key '40002' must be a list, got 'str'.
+Checking consistency of 'test36-bad-key-mapping.sid'

--- a/test/test_sid/test-37-expected-output.txt
+++ b/test/test_sid/test-37-expected-output.txt
@@ -1,0 +1,2 @@
+ERROR in 'test37-bad-key-mapping.sid', key-mapping value for key '40002' at index 0 must be an integer, got 'str'.
+Checking consistency of 'test37-bad-key-mapping.sid'

--- a/test/test_sid/test-38-expected-output.txt
+++ b/test/test_sid/test-38-expected-output.txt
@@ -1,0 +1,2 @@
+ERROR in 'test38-bad-key-mapping.sid', key-mapping value for key '40002' at index 0 must be a positive integer, got -100.
+Checking consistency of 'test38-bad-key-mapping.sid'

--- a/test/test_sid/test-with-key-mapping.yang
+++ b/test/test_sid/test-with-key-mapping.yang
@@ -1,0 +1,31 @@
+module test-with-key-mapping {
+  namespace "http://example.com/test-key-mapping";
+  prefix tkm;
+
+  revision 2026-04-16;
+
+  container devices {
+    list device {
+      key "device-id";
+      leaf device-id {
+        type uint32;
+      }
+      leaf name {
+        type string;
+      }
+    }
+
+    list interface {
+      key "if-name if-type";
+      leaf if-name {
+        type string;
+      }
+      leaf if-type {
+        type string;
+      }
+      leaf status {
+        type string;
+      }
+    }
+  }
+}

--- a/test/test_sid/test36-bad-key-mapping.sid
+++ b/test/test_sid/test36-bad-key-mapping.sid
@@ -1,0 +1,24 @@
+{
+  "ietf-sid-file:sid-file": {
+    "module-name": "test-with-key-mapping",
+    "module-revision": "2026-04-16",
+    "sid-file-status": "unpublished",
+    "assignment-range": [
+      {
+        "entry-point": "40000",
+        "size": "20"
+      }
+    ],
+    "item": [
+      {
+        "namespace": "module",
+        "identifier": "test-with-key-mapping",
+        "status": "unstable",
+        "sid": "40000"
+      }
+    ],
+    "key-mapping": {
+      "40002": "not-a-list"
+    }
+  }
+}

--- a/test/test_sid/test37-bad-key-mapping.sid
+++ b/test/test_sid/test37-bad-key-mapping.sid
@@ -1,0 +1,27 @@
+{
+  "ietf-sid-file:sid-file": {
+    "module-name": "test-with-key-mapping",
+    "module-revision": "2026-04-16",
+    "sid-file-status": "unpublished",
+    "assignment-range": [
+      {
+        "entry-point": "40000",
+        "size": "20"
+      }
+    ],
+    "item": [
+      {
+        "namespace": "module",
+        "identifier": "test-with-key-mapping",
+        "status": "unstable",
+        "sid": "40000"
+      }
+    ],
+    "key-mapping": {
+      "40002": [
+        "not-a-number",
+        40003
+      ]
+    }
+  }
+}

--- a/test/test_sid/test38-bad-key-mapping.sid
+++ b/test/test_sid/test38-bad-key-mapping.sid
@@ -1,0 +1,27 @@
+{
+  "ietf-sid-file:sid-file": {
+    "module-name": "test-with-key-mapping",
+    "module-revision": "2026-04-16",
+    "sid-file-status": "unpublished",
+    "assignment-range": [
+      {
+        "entry-point": "40000",
+        "size": "20"
+      }
+    ],
+    "item": [
+      {
+        "namespace": "module",
+        "identifier": "test-with-key-mapping",
+        "status": "unstable",
+        "sid": "40000"
+      }
+    ],
+    "key-mapping": {
+      "40002": [
+        -100,
+        40003
+      ]
+    }
+  }
+}


### PR DESCRIPTION
When I was running validation for .sid files that contained key-mappings, they were failing because that entry was not in the list of validations. This PR adds that check, along with the validation method and the unit tests for the change. Let me know what comments you have.