### PR TITLE
[sid-extension] Fix test1 to make debugging easier

### DIFF
--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -55,6 +55,10 @@ class SidPlugin(plugin.PyangPlugin):
                          action="store_true",
                          dest="list_sid",
                          help="Print the list of SID."),
+            optparse.make_option("--sid-extension",
+                         action="store_true",
+                         dest="sid_ext",
+                         help="Add info to the sid file to manipulate CORECONF."),
             optparse.make_option("--sid-finalize",
                          action="store_true",
                          dest="finalize_sid",
@@ -138,6 +142,9 @@ class SidPlugin(plugin.PyangPlugin):
 
         if ctx.opts.list_sid:
             sid_file.list_content = True
+
+        if ctx.opts.sid_ext:
+            sid_file.sid_extension = True
 
         if ctx.opts.finalize_sid:
             print("Will mark unstable allocations finalized")
@@ -240,6 +247,13 @@ OPTIONS
   obtains the list of SIDs assigned or validated. For example:
 
   $ pyang --sid-list --sid-generate-file 20000:100 toaster@2009-11-20.yang
+          
+--sid-extension
+
+   Add non standard entries in the .sid file to facilitate CORECONF manipulation
+   on constrained devices. 
+
+  $ pyang --sid-list --sid-generate-file 20000:100 --sid-extension toaster@2009-11-20.yang
 
 --sid-finalize
 
@@ -309,6 +323,7 @@ class SidFile:
         self.module_revision = ''
         self.output_file_name = ''
         self.update = False
+        self.sid_extension = False
 
     def process_sid_file(self, module):
         self.module_name = module.i_modulename
@@ -664,6 +679,9 @@ class SidFile:
         if 'item' not in self.content:
             self.content['item'] = []
 
+        if self.sid_extension and 'key-mapping' not in self.content: 
+            self.content['key-mapping'] = {}
+
         for item in self.content['item']:
             # Set to 'd' deleted, updated to 'o' if present in .yang file
             item['lifecycle'] = 'd'
@@ -717,10 +735,37 @@ class SidFile:
     def collect_inner_data_nodes(self, statements, prefix=""):
         for statement in statements:
             if statement.keyword in self.leaf_keywords:
-                self.merge_item('data', self.get_path(statement, prefix))
+                if self.sid_extension:
+                    for s in statement.substmts: # find type declaration
+                        print (s)
+                        if s.keyword == "type":
+                            if s.i_type_spec.name == "identityref":
+                                typename = "identityref"
+
+                            elif s.i_type_spec.name == "enumeration":
+                                typename = {}
+                                for k, v in s.i_type_spec.enums:
+                                    typename[str(v)] = k
+                            else:
+                                typename = s.arg
+
+                            if typename=="union": # union put all types in an array
+                                typename = []
+                                for t in s.i_type_spec.types:
+                                    typename.append(t.arg)
+                self.merge_item('data', self.get_path(statement, prefix), typename if self.sid_extension else None)
 
             elif statement.keyword in self.container_keywords:
                 self.merge_item('data', self.get_path(statement, prefix))
+                if self.sid_extension: # create key-mapping for list, with the path of the keys as value
+                    if statement.keyword == "list":
+                        keys = []
+        
+                        if hasattr(statement, 'i_key') and statement.i_key:
+                            for k in statement.i_key:
+                                keys.append(self.get_path(k, prefix))
+        
+                        self.content["key-mapping"][self.get_path(statement, prefix)] = keys
                 self.collect_inner_data_nodes(statement.i_children, prefix)
 
             elif statement.keyword in self.choice_keywords:
@@ -792,16 +837,23 @@ class SidFile:
             statement = statement.parent
         return prefix + path
 
-    def merge_item(self, namespace, identifier):
+    def merge_item(self, namespace, identifier, typename=None):
         for item in self.content['item']:
             if (namespace == item['namespace'] and
                     identifier == item['identifier']):
                 item['lifecycle'] = 'o' # Item already assigned
                 return
-        self.content['item'].append(collections.OrderedDict(
-            [('namespace', namespace), ('identifier', identifier),
-             ('status', 'unstable'),
-             ('sid', -1), ('lifecycle', 'n')]))
+            
+        if self.sid_extension and typename is not None:
+            self.content['item'].append(collections.OrderedDict(
+                [('namespace', namespace), ('identifier', identifier),
+                 ('status', 'unstable'),
+                 ('sid', -1), ('lifecycle', 'n'), ('type', typename)]))
+        else:   
+            self.content['item'].append(collections.OrderedDict(
+                [('namespace', namespace), ('identifier', identifier),
+                ('status', 'unstable'),
+                ('sid', -1), ('lifecycle', 'n')]))
         self.is_consistent = False
 
     ########################################################
@@ -973,6 +1025,14 @@ class SidFile:
                   "with a 'deprecated' or 'obsolete' status.")
 
     ########################################################
+
+    def find_sid(self, id):
+        for e in self.content['item']:
+            if e['identifier'] == id:
+                return e['sid']
+        return None
+
+
     def generate_file(self):
         for item in self.content['item']:
             del item['lifecycle']
@@ -1020,6 +1080,18 @@ class SidFile:
                     print("  finalized %s" % (item['identifier']))
                     # status 'stable' is default enum
                     del item['status']
+
+        if self.sid_extension:
+            key_mapping_sid = {}
+            for k, v in self.content['key-mapping'].items():
+                k_sid = self.find_sid(k)
+                v_sids = []
+                for e in v:
+                    v_sids.append(self.find_sid(e))
+                key_mapping_sid[k_sid] = v_sids
+
+            sid_cont['key-mapping'] = key_mapping_sid
+
 
         with open(self.output_file_name, 'w') as outfile:
             outfile.truncate(0)

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -699,9 +699,11 @@ class SidFile:
             if statement.keyword in self.leaf_keywords:
                 self.merge_item('data', self.get_path(statement))
 
-            elif (statement.keyword in self.module_container_keywords or 
-                  statement.keyword in self.choice_keywords):
+            elif statement.keyword in self.module_container_keywords:
                 self.merge_item('data', self.get_path(statement))
+                self.collect_inner_data_nodes(statement.i_children)
+
+            elif statement.keyword in self.choice_keywords:
                 self.collect_inner_data_nodes(statement.i_children)
 
             elif statement.keyword == 'rpc':
@@ -725,7 +727,13 @@ class SidFile:
 
         for substmt in module.substmts:
             if substmt.keyword == 'augment':
-                self.collect_in_substmts(substmt.substmts)
+                target = substmt.i_target_node
+                if target.keyword != 'choice' and target.parent not in ('module', 'submodule'):
+                    self.collect_in_substmts(substmt.substmts)
+                else:
+                    # Do not emit items for top-level case nodes (case nodes children of toplevel choice)
+                    for case_child in substmt.i_children:
+                        self.collect_in_substmts(case_child.substmts)
             elif self.has_yang_data_extension(substmt):
                 self.collect_in_substmts(substmt.substmts)
             elif substmt.keyword == \
@@ -810,28 +818,31 @@ class SidFile:
     def get_path(self, statement, prefix=""):
         path = ""
 
-        #breakpoint()
-
         while statement.i_module is not None:
             if (statement.keyword != 'grouping'
                     and not self.has_yang_data_extension(statement)):
-                # Locate the data node parent
-                parent = statement.parent
-                while parent.i_module is not None:
-                    if (parent.keyword in self.module_keywords or
-                            parent.keyword ==
+                module = statement.parent
+                while module.i_module is not None:
+                    if (module.keyword in self.module_keywords or
+                            module.keyword ==
                             ('ietf-yang-structure-ext', 'structure') or
-                            parent.keyword ==
+                            module.keyword ==
                             ('ietf-yang-structure-ext', 'augment-structure')):
                         break
-                    parent = parent.parent
+                    module = module.parent
 
+                parent_is_toplevel_case = (statement.parent.keyword == 'case' and
+                        statement.parent.parent.parent.keyword in ("module", "submodule"))
+                if parent_is_toplevel_case:
+                    path = "/" + statement.i_module.arg + ":" + statement.arg \
+                            + path
+                    break
                 if (prefix != "" or
-                        (parent.i_module is not None and
-                         parent.i_module == statement.i_module) or
-                        (statement.keyword == 'case' and 
+                        (module.i_module is not None and
+                         module.i_module == statement.i_module) or
+                        (statement.keyword == 'case' and
                          statement.i_module == statement.parent.i_module) or
-                        (statement.parent.keyword == 'case' and 
+                        (statement.parent.keyword == 'case' and
                          statement.i_module == statement.parent.i_module)):
                     if statement.keyword not in ('case', 'choice'):
                         path = "/" + statement.arg + path

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -800,6 +800,7 @@ class SidFile:
 
                     if typename=="union": # union put all types in an array
                         typename = []
+                        print ("UNION type found for %s, collecting types in an array" % self.get_path(statement))
                         for t in s.i_type_spec.types:
                             if s.i_type_spec.name == "identityref":
                                 typename.append("identityref")

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -802,7 +802,7 @@ class SidFile:
                         typename = []
                         for t in s.i_type_spec.types:
                             if t.i_type_spec.name == "identityref":
-                                typename.append("identityref")
+                                typename.insert(0, "identityref") # put identityref first in the list as it is more specific than other types
                             else:
                                 typename.append(t.arg)
         self.merge_item('data', self.get_path(statement), typename if self.sid_extension else None)

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -737,7 +737,6 @@ class SidFile:
             if statement.keyword in self.leaf_keywords:
                 if self.sid_extension:
                     for s in statement.substmts: # find type declaration
-                        print (s)
                         if s.keyword == "type":
                             if s.i_type_spec.name == "identityref":
                                 typename = "identityref"

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -800,7 +800,7 @@ class SidFile:
 
                     if typename=="union": # union put all types in an array
                         typename = []
-                        print ("UNION type found for %s, collecting types in an array" % self.get_path(statement))
+                        print ("UNION type found for %s, collecting types in an array" % s.i_type_spec.name)
                         for t in s.i_type_spec.types:
                             if s.i_type_spec.name == "identityref":
                                 typename.append("identityref")

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -847,7 +847,7 @@ class SidFile:
                     if statement.keyword not in ('case', 'choice'):
                         path = "/" + statement.arg + path
                 else:
-                    path = "/" + statement.i_module.arg + ":" + statement.arg \
+                    path = "/" + statement.main_module().arg + ":" + statement.arg \
                             + path
 
             statement = statement.parent

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -801,7 +801,10 @@ class SidFile:
                     if typename=="union": # union put all types in an array
                         typename = []
                         for t in s.i_type_spec.types:
-                            typename.append(t.arg)
+                            if s.i_type_spec.name == "identityref":
+                                typename.append("identityref")
+                            else:
+                                typename.append(t.arg)
         self.merge_item('data', self.get_path(statement), typename if self.sid_extension else None)
 
     def get_path(self, statement, prefix=""):

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -735,24 +735,7 @@ class SidFile:
     def collect_inner_data_nodes(self, statements, prefix=""):
         for statement in statements:
             if statement.keyword in self.leaf_keywords:
-                if self.sid_extension:
-                    for s in statement.substmts: # find type declaration
-                        if s.keyword == "type":
-                            if s.i_type_spec.name == "identityref":
-                                typename = "identityref"
-
-                            elif s.i_type_spec.name == "enumeration":
-                                typename = {}
-                                for k, v in s.i_type_spec.enums:
-                                    typename[str(v)] = k
-                            else:
-                                typename = s.arg
-
-                            if typename=="union": # union put all types in an array
-                                typename = []
-                                for t in s.i_type_spec.types:
-                                    typename.append(t.arg)
-                self.merge_item('data', self.get_path(statement, prefix), typename if self.sid_extension else None)
+                self.collect_in_leaf(statement)
 
             elif statement.keyword in self.container_keywords:
                 self.merge_item('data', self.get_path(statement, prefix))
@@ -789,24 +772,7 @@ class SidFile:
     def collect_in_substmts(self, substmts):
         for statement in substmts:
             if statement.keyword in self.leaf_keywords:
-                if self.sid_extension:
-                    for s in statement.substmts: # find type declaration
-                        if s.keyword == "type":
-                            if s.i_type_spec.name == "identityref":
-                                typename = "identityref"
-
-                            elif s.i_type_spec.name == "enumeration":
-                                typename = {}
-                                for k, v in s.i_type_spec.enums:
-                                    typename[str(v)] = k
-                            else:
-                                typename = s.arg
-
-                            if typename=="union": # union put all types in an array
-                                typename = []
-                                for t in s.i_type_spec.types:
-                                    typename.append(t.arg)
-                self.merge_item('data', self.get_path(statement), typename if self.sid_extension else None)
+                self.collect_in_leaf(statement)
 
             elif (statement.keyword in self.container_keywords or
                   statement.keyword in self.choice_keywords):
@@ -817,6 +783,26 @@ class SidFile:
                 prefix = self.get_path(statement.parent)
                 self.collect_inner_data_nodes(statement.i_grouping.i_children,
                                               prefix)
+
+    def collect_in_leaf(self, statement):
+        if self.sid_extension:
+            for s in statement.substmts: # find type declaration
+                if s.keyword == "type":
+                    if s.i_type_spec.name == "identityref":
+                        typename = "identityref"
+
+                    elif s.i_type_spec.name == "enumeration":
+                        typename = {}
+                        for k, v in s.i_type_spec.enums:
+                            typename[str(v)] = k
+                    else:
+                        typename = s.arg
+
+                    if typename=="union": # union put all types in an array
+                        typename = []
+                        for t in s.i_type_spec.types:
+                            typename.append(t.arg)
+        self.merge_item('data', self.get_path(statement), typename if self.sid_extension else None)
 
     def get_path(self, statement, prefix=""):
         path = ""

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -800,9 +800,8 @@ class SidFile:
 
                     if typename=="union": # union put all types in an array
                         typename = []
-                        print ("UNION type found for %s, collecting types in an array" % s.i_type_spec.name)
                         for t in s.i_type_spec.types:
-                            if s.i_type_spec.name == "identityref":
+                            if t.i_type_spec.name == "identityref":
                                 typename.append("identityref")
                             else:
                                 typename.append(t.arg)

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -789,7 +789,24 @@ class SidFile:
     def collect_in_substmts(self, substmts):
         for statement in substmts:
             if statement.keyword in self.leaf_keywords:
-                self.merge_item('data', self.get_path(statement))
+                if self.sid_extension:
+                    for s in statement.substmts: # find type declaration
+                        if s.keyword == "type":
+                            if s.i_type_spec.name == "identityref":
+                                typename = "identityref"
+
+                            elif s.i_type_spec.name == "enumeration":
+                                typename = {}
+                                for k, v in s.i_type_spec.enums:
+                                    typename[str(v)] = k
+                            else:
+                                typename = s.arg
+
+                            if typename=="union": # union put all types in an array
+                                typename = []
+                                for t in s.i_type_spec.types:
+                                    typename.append(t.arg)
+                self.merge_item('data', self.get_path(statement), typename if self.sid_extension else None)
 
             elif (statement.keyword in self.container_keywords or
                   statement.keyword in self.choice_keywords):

--- a/test/test_sid/Makefile
+++ b/test/test_sid/Makefile
@@ -2,7 +2,9 @@ PYANG?= pyang
 
 .PHONY: test test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 \
 	test12 test14 test15 test16 test17 test18 test19 test20 test21 test22 test23 \
-	test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34
+	test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34 \
+	test41
+
 test: test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 \
 	test12 test14 test15 test16 test17 test18 test19 test20 test21 test22 \
 	test23 test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34
@@ -195,4 +197,8 @@ test34: aug-a@2025-08-25.yang aug-b@2025-08-25.yang aug-c@2025-08-25.yang test-3
 	$(PYANG) --sid-generate-file 1200:100 aug-c@2025-08-25.yang --sid-finalize >/dev/null 2>/dev/null
 	diff -b aug-c@2025-08-25.sid test-34-expected-aug-c.sid
 	rm aug-a@2025-08-25.sid aug-b@2025-08-25.sid aug-c@2025-08-25.sid
+
+test41: main@2026-03-20.yang a-sub@2026-03-20.yang b-sub@2026-03-20.yang x-sub@2026-03-20.yang
+	$(PYANG) --sid-generate-file 1000:100 main@2026-03-20.yang
+	diff -b main@2026-03-20.sid test-41-expected-main.sid
 

--- a/test/test_sid/Makefile
+++ b/test/test_sid/Makefile
@@ -7,7 +7,8 @@ PYANG?= pyang
 
 test: test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 \
 	test12 test14 test15 test16 test17 test18 test19 test20 test21 test22 \
-	test23 test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34
+	test23 test24 test25 test26 test27 test28 test29 test30 test31 test32 test33 test34 \
+	test41
 
 test1:
 	# Test help
@@ -199,6 +200,7 @@ test34: aug-a@2025-08-25.yang aug-b@2025-08-25.yang aug-c@2025-08-25.yang test-3
 	rm aug-a@2025-08-25.sid aug-b@2025-08-25.sid aug-c@2025-08-25.sid
 
 test41: main@2026-03-20.yang a-sub@2026-03-20.yang b-sub@2026-03-20.yang x-sub@2026-03-20.yang
-	$(PYANG) --sid-generate-file 1000:100 main@2026-03-20.yang
+	$(PYANG) --sid-generate-file 1000:100 main@2026-03-20.yang >/dev/null 2>/dev/null
 	diff -b main@2026-03-20.sid test-41-expected-main.sid
+	rm main@2026-03-20.sid
 

--- a/test/test_sid/a-sub@2026-03-20.yang
+++ b/test/test_sid/a-sub@2026-03-20.yang
@@ -1,0 +1,18 @@
+submodule a-sub {
+  yang-version 1.1;
+  belongs-to main {
+    prefix main;
+  }
+
+  revision 2026-03-20;
+
+  feature a-sub-f;
+
+  identity a-misc-id;
+
+  container b-a {
+    leaf value {
+      type string;
+    }
+  }
+}

--- a/test/test_sid/b-sub@2026-03-20.yang
+++ b/test/test_sid/b-sub@2026-03-20.yang
@@ -1,0 +1,17 @@
+submodule b-sub {
+  yang-version 1.1;
+  belongs-to main {
+    prefix main;
+  }
+
+  revision 2026-03-20;
+
+  feature b-sub-f;
+  identity b-misc-id;
+
+  container c {
+    leaf counter {
+      type uint32;
+    }
+  }
+}

--- a/test/test_sid/main@2026-03-20.yang
+++ b/test/test_sid/main@2026-03-20.yang
@@ -1,0 +1,31 @@
+module main {
+  yang-version 1.1;
+  namespace "urn:example:main";
+  prefix m;
+
+  include a-sub;
+  include b-sub {
+    revision-date 2026-03-20;
+  }
+  include x-sub {
+    revision-date 2026-03-20;
+  }
+
+  revision 2026-03-20;
+
+  feature main-f;
+
+  identity base-identity;
+  identity derived-identity {
+    base base-identity;
+  }
+
+  container a-system {
+    leaf name {
+      type string;
+    }
+    leaf uptime {
+      type string;
+    }
+  }
+}

--- a/test/test_sid/test-1-expected-output.txt
+++ b/test/test_sid/test-1-expected-output.txt
@@ -69,6 +69,13 @@ OPTIONS
 
   $ pyang --sid-list --sid-generate-file 20000:100 toaster@2009-11-20.yang
 
+--sid-extension
+
+   Add non standard entries in the .sid file to facilitate CORECONF manipulation
+   on constrained devices. 
+
+  $ pyang --sid-list --sid-generate-file 20000:100 --sid-extension toaster@2009-11-20.yang
+
 --sid-finalize
 
   New allocations when during development of a protocol are marked as

--- a/test/test_sid/test-20-expected-output.txt
+++ b/test/test_sid/test-20-expected-output.txt
@@ -4,4 +4,4 @@ WARNING: Module 'ieee802-dot1q-stream-filters-gates' imported without revision, 
 
 File ieee802-dot1q-psfp@2020-07-07.sid created
 Number of SIDs available : 100
-Number of SIDs used : 48
+Number of SIDs used : 34

--- a/test/test_sid/test-24-expected-ietf-system@2014-08-06.sid
+++ b/test/test_sid/test-24-expected-ietf-system@2014-08-06.sid
@@ -254,228 +254,183 @@
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/clock/timezone",
+        "identifier": "/ietf-system:system/clock/timezone-name",
         "sid": "1745"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/clock/timezone/timezone-name",
+        "identifier": "/ietf-system:system/clock/timezone-utc-offset",
         "sid": "1746"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/clock/timezone/timezone-name/timezone-name",
+        "identifier": "/ietf-system:system/contact",
         "sid": "1747"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/clock/timezone/timezone-utc-offset",
+        "identifier": "/ietf-system:system/dns-resolver",
         "sid": "1748"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/clock/timezone/timezone-utc-offset/timezone-utc-offset",
+        "identifier": "/ietf-system:system/dns-resolver/options",
         "sid": "1749"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/contact",
+        "identifier": "/ietf-system:system/dns-resolver/options/attempts",
         "sid": "1750"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver",
+        "identifier": "/ietf-system:system/dns-resolver/options/timeout",
         "sid": "1751"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/options",
+        "identifier": "/ietf-system:system/dns-resolver/search",
         "sid": "1752"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/options/attempts",
+        "identifier": "/ietf-system:system/dns-resolver/server",
         "sid": "1753"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/options/timeout",
+        "identifier": "/ietf-system:system/dns-resolver/server/name",
         "sid": "1754"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/search",
+        "identifier": "/ietf-system:system/dns-resolver/server/udp-and-tcp",
         "sid": "1755"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server",
+        "identifier": "/ietf-system:system/dns-resolver/server/udp-and-tcp/address",
         "sid": "1756"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/name",
+        "identifier": "/ietf-system:system/dns-resolver/server/udp-and-tcp/port",
         "sid": "1757"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/transport",
+        "identifier": "/ietf-system:system/hostname",
         "sid": "1758"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/transport/udp-and-tcp",
+        "identifier": "/ietf-system:system/location",
         "sid": "1759"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/transport/udp-and-tcp/udp-and-tcp",
+        "identifier": "/ietf-system:system/ntp",
         "sid": "1760"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/transport/udp-and-tcp/udp-and-tcp/address",
+        "identifier": "/ietf-system:system/ntp/enabled",
         "sid": "1761"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/transport/udp-and-tcp/udp-and-tcp/port",
+        "identifier": "/ietf-system:system/ntp/server",
         "sid": "1762"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/hostname",
+        "identifier": "/ietf-system:system/ntp/server/association-type",
         "sid": "1763"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/location",
+        "identifier": "/ietf-system:system/ntp/server/iburst",
         "sid": "1764"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp",
+        "identifier": "/ietf-system:system/ntp/server/name",
         "sid": "1765"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/enabled",
+        "identifier": "/ietf-system:system/ntp/server/prefer",
         "sid": "1766"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server",
+        "identifier": "/ietf-system:system/ntp/server/udp",
         "sid": "1767"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/association-type",
+        "identifier": "/ietf-system:system/ntp/server/udp/address",
         "sid": "1768"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/iburst",
+        "identifier": "/ietf-system:system/ntp/server/udp/port",
         "sid": "1769"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/name",
+        "identifier": "/ietf-system:system/radius",
         "sid": "1770"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/prefer",
+        "identifier": "/ietf-system:system/radius/options",
         "sid": "1771"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/transport",
+        "identifier": "/ietf-system:system/radius/options/attempts",
         "sid": "1772"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/transport/udp",
+        "identifier": "/ietf-system:system/radius/options/timeout",
         "sid": "1773"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/transport/udp/udp",
+        "identifier": "/ietf-system:system/radius/server",
         "sid": "1774"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/transport/udp/udp/address",
+        "identifier": "/ietf-system:system/radius/server/authentication-type",
         "sid": "1775"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/transport/udp/udp/port",
+        "identifier": "/ietf-system:system/radius/server/name",
         "sid": "1776"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius",
+        "identifier": "/ietf-system:system/radius/server/udp",
         "sid": "1777"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/options",
+        "identifier": "/ietf-system:system/radius/server/udp/address",
         "sid": "1778"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/options/attempts",
+        "identifier": "/ietf-system:system/radius/server/udp/authentication-port",
         "sid": "1779"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/options/timeout",
+        "identifier": "/ietf-system:system/radius/server/udp/shared-secret",
         "sid": "1780"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server",
-        "sid": "1781"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/authentication-type",
-        "sid": "1782"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/name",
-        "sid": "1783"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/transport",
-        "sid": "1784"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/transport/udp",
-        "sid": "1785"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/transport/udp/udp",
-        "sid": "1786"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/transport/udp/udp/address",
-        "sid": "1787"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/transport/udp/udp/authentication-port",
-        "sid": "1788"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/transport/udp/udp/shared-secret",
-        "sid": "1789"
       }
     ]
   }

--- a/test/test_sid/test-24-expected-output.txt
+++ b/test/test_sid/test-24-expected-output.txt
@@ -49,11 +49,8 @@ Finalizing unstable allocations to 2014-08-06
   finalized /ietf-system:system/authentication/user/name
   finalized /ietf-system:system/authentication/user/password
   finalized /ietf-system:system/clock
-  finalized /ietf-system:system/clock/timezone
-  finalized /ietf-system:system/clock/timezone/timezone-name
-  finalized /ietf-system:system/clock/timezone/timezone-name/timezone-name
-  finalized /ietf-system:system/clock/timezone/timezone-utc-offset
-  finalized /ietf-system:system/clock/timezone/timezone-utc-offset/timezone-utc-offset
+  finalized /ietf-system:system/clock/timezone-name
+  finalized /ietf-system:system/clock/timezone-utc-offset
   finalized /ietf-system:system/contact
   finalized /ietf-system:system/dns-resolver
   finalized /ietf-system:system/dns-resolver/options
@@ -62,11 +59,9 @@ Finalizing unstable allocations to 2014-08-06
   finalized /ietf-system:system/dns-resolver/search
   finalized /ietf-system:system/dns-resolver/server
   finalized /ietf-system:system/dns-resolver/server/name
-  finalized /ietf-system:system/dns-resolver/server/transport
-  finalized /ietf-system:system/dns-resolver/server/transport/udp-and-tcp
-  finalized /ietf-system:system/dns-resolver/server/transport/udp-and-tcp/udp-and-tcp
-  finalized /ietf-system:system/dns-resolver/server/transport/udp-and-tcp/udp-and-tcp/address
-  finalized /ietf-system:system/dns-resolver/server/transport/udp-and-tcp/udp-and-tcp/port
+  finalized /ietf-system:system/dns-resolver/server/udp-and-tcp
+  finalized /ietf-system:system/dns-resolver/server/udp-and-tcp/address
+  finalized /ietf-system:system/dns-resolver/server/udp-and-tcp/port
   finalized /ietf-system:system/hostname
   finalized /ietf-system:system/location
   finalized /ietf-system:system/ntp
@@ -76,11 +71,9 @@ Finalizing unstable allocations to 2014-08-06
   finalized /ietf-system:system/ntp/server/iburst
   finalized /ietf-system:system/ntp/server/name
   finalized /ietf-system:system/ntp/server/prefer
-  finalized /ietf-system:system/ntp/server/transport
-  finalized /ietf-system:system/ntp/server/transport/udp
-  finalized /ietf-system:system/ntp/server/transport/udp/udp
-  finalized /ietf-system:system/ntp/server/transport/udp/udp/address
-  finalized /ietf-system:system/ntp/server/transport/udp/udp/port
+  finalized /ietf-system:system/ntp/server/udp
+  finalized /ietf-system:system/ntp/server/udp/address
+  finalized /ietf-system:system/ntp/server/udp/port
   finalized /ietf-system:system/radius
   finalized /ietf-system:system/radius/options
   finalized /ietf-system:system/radius/options/attempts
@@ -88,13 +81,11 @@ Finalizing unstable allocations to 2014-08-06
   finalized /ietf-system:system/radius/server
   finalized /ietf-system:system/radius/server/authentication-type
   finalized /ietf-system:system/radius/server/name
-  finalized /ietf-system:system/radius/server/transport
-  finalized /ietf-system:system/radius/server/transport/udp
-  finalized /ietf-system:system/radius/server/transport/udp/udp
-  finalized /ietf-system:system/radius/server/transport/udp/udp/address
-  finalized /ietf-system:system/radius/server/transport/udp/udp/authentication-port
-  finalized /ietf-system:system/radius/server/transport/udp/udp/shared-secret
+  finalized /ietf-system:system/radius/server/udp
+  finalized /ietf-system:system/radius/server/udp/address
+  finalized /ietf-system:system/radius/server/udp/authentication-port
+  finalized /ietf-system:system/radius/server/udp/shared-secret
 
 File ietf-system@2014-08-06.sid created
 Number of SIDs available : 100
-Number of SIDs used : 90
+Number of SIDs used : 81

--- a/test/test_sid/test-33-expected-choice-case.sid
+++ b/test/test_sid/test-33-expected-choice-case.sid
@@ -20,123 +20,78 @@
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box",
+        "identifier": "/choice-case:a",
         "sid": "60002"
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box/boxed",
+        "identifier": "/choice-case:b",
         "sid": "60003"
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box/boxed/ipv4_prefix",
+        "identifier": "/choice-case:box",
         "sid": "60004"
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box/boxed/ipv4_prefix/ipv4_length",
+        "identifier": "/choice-case:box/ipv4_length",
         "sid": "60005"
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box/boxed/ipv4_prefix/ipv4_network",
+        "identifier": "/choice-case:box/ipv4_network",
         "sid": "60006"
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box/boxed/ipv6_prefix",
+        "identifier": "/choice-case:box/ipv6_length",
         "sid": "60007"
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box/boxed/ipv6_prefix/ipv6_length",
+        "identifier": "/choice-case:box/ipv6_network",
         "sid": "60008"
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box/boxed/ipv6_prefix/ipv6_network",
+        "identifier": "/choice-case:box/pair",
         "sid": "60009"
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box/implicit_case",
+        "identifier": "/choice-case:box/pair/s",
         "sid": "60010"
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box/implicit_case/pair",
+        "identifier": "/choice-case:box/pair/t",
         "sid": "60011"
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box/implicit_case/pair/pair",
+        "identifier": "/choice-case:box/triple",
         "sid": "60012"
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box/implicit_case/pair/pair/s",
+        "identifier": "/choice-case:box/triple/x",
         "sid": "60013"
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box/implicit_case/pair/pair/t",
+        "identifier": "/choice-case:box/triple/y",
         "sid": "60014"
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box/implicit_case/triple",
+        "identifier": "/choice-case:box/triple/z",
         "sid": "60015"
       },
       {
         "namespace": "data",
-        "identifier": "/choice-case:box/implicit_case/triple/triple",
+        "identifier": "/choice-case:c",
         "sid": "60016"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/choice-case:box/implicit_case/triple/triple/x",
-        "sid": "60017"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/choice-case:box/implicit_case/triple/triple/y",
-        "sid": "60018"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/choice-case:box/implicit_case/triple/triple/z",
-        "sid": "60019"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/choice-case:top-level",
-        "sid": "60020"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/choice-case:top-level/ab",
-        "sid": "60021"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/choice-case:top-level/ab/a",
-        "sid": "60022"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/choice-case:top-level/ab/b",
-        "sid": "60023"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/choice-case:top-level/c",
-        "sid": "60024"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/choice-case:top-level/c/c",
-        "sid": "60025"
       }
     ]
   }

--- a/test/test_sid/test-34-expected-aug-a.sid
+++ b/test/test_sid/test-34-expected-aug-a.sid
@@ -16,23 +16,8 @@
       },
       {
         "namespace": "data",
-        "identifier": "/aug-a:top-level",
+        "identifier": "/aug-a:a",
         "sid": "1001"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/aug-a:top-level/a",
-        "sid": "1002"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/aug-a:top-level/a/a",
-        "sid": "1003"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/aug-a:top-level/b",
-        "sid": "1004"
       }
     ]
   }

--- a/test/test_sid/test-34-expected-aug-b.sid
+++ b/test/test_sid/test-34-expected-aug-b.sid
@@ -22,23 +22,13 @@
       },
       {
         "namespace": "data",
-        "identifier": "/aug-a:top-level/aug-b:c",
+        "identifier": "/aug-b:b",
         "sid": "1101"
       },
       {
         "namespace": "data",
-        "identifier": "/aug-a:top-level/aug-b:c/c",
+        "identifier": "/aug-b:c",
         "sid": "1102"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/aug-a:top-level/aug-b:d",
-        "sid": "1103"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/aug-a:top-level/b/aug-b:b",
-        "sid": "1104"
       }
     ]
   }

--- a/test/test_sid/test-34-expected-aug-c.sid
+++ b/test/test_sid/test-34-expected-aug-c.sid
@@ -26,7 +26,7 @@
       },
       {
         "namespace": "data",
-        "identifier": "/aug-a:top-level/aug-b:d/aug-c:d",
+        "identifier": "/aug-c:d",
         "sid": "1201"
       }
     ]

--- a/test/test_sid/test-41-expected-main.sid
+++ b/test/test_sid/test-41-expected-main.sid
@@ -1,0 +1,135 @@
+{
+  "ietf-sid-file:sid-file": {
+    "module-name": "main",
+    "module-revision": "2026-03-20",
+    "sid-file-status": "unpublished",
+    "assignment-range": [
+      {
+        "entry-point": "1000",
+        "size": "100"
+      }
+    ],
+    "item": [
+      {
+        "namespace": "module",
+        "identifier": "a-sub",
+        "status": "unstable",
+        "sid": "1000"
+      },
+      {
+        "namespace": "module",
+        "identifier": "b-sub",
+        "status": "unstable",
+        "sid": "1001"
+      },
+      {
+        "namespace": "module",
+        "identifier": "main",
+        "status": "unstable",
+        "sid": "1002"
+      },
+      {
+        "namespace": "module",
+        "identifier": "x-sub",
+        "status": "unstable",
+        "sid": "1003"
+      },
+      {
+        "namespace": "identity",
+        "identifier": "a-misc-id",
+        "status": "unstable",
+        "sid": "1004"
+      },
+      {
+        "namespace": "identity",
+        "identifier": "b-misc-id",
+        "status": "unstable",
+        "sid": "1005"
+      },
+      {
+        "namespace": "identity",
+        "identifier": "base-identity",
+        "status": "unstable",
+        "sid": "1006"
+      },
+      {
+        "namespace": "identity",
+        "identifier": "derived-identity",
+        "status": "unstable",
+        "sid": "1007"
+      },
+      {
+        "namespace": "identity",
+        "identifier": "x-misc-id",
+        "status": "unstable",
+        "sid": "1008"
+      },
+      {
+        "namespace": "feature",
+        "identifier": "a-sub-f",
+        "status": "unstable",
+        "sid": "1009"
+      },
+      {
+        "namespace": "feature",
+        "identifier": "b-sub-f",
+        "status": "unstable",
+        "sid": "1010"
+      },
+      {
+        "namespace": "feature",
+        "identifier": "main-f",
+        "status": "unstable",
+        "sid": "1011"
+      },
+      {
+        "namespace": "feature",
+        "identifier": "x-sub-f",
+        "status": "unstable",
+        "sid": "1012"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/main:a-system",
+        "status": "unstable",
+        "sid": "1013"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/main:a-system/name",
+        "status": "unstable",
+        "sid": "1014"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/main:a-system/uptime",
+        "status": "unstable",
+        "sid": "1015"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/main:b-a",
+        "status": "unstable",
+        "sid": "1016"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/main:b-a/value",
+        "status": "unstable",
+        "sid": "1017"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/main:c",
+        "status": "unstable",
+        "sid": "1018"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/main:c/counter",
+        "status": "unstable",
+        "sid": "1019"
+      }
+    ]
+  }
+}

--- a/test/test_sid/x-sub@2026-03-20.yang
+++ b/test/test_sid/x-sub@2026-03-20.yang
@@ -1,0 +1,19 @@
+submodule x-sub {
+  yang-version 1.1;
+  belongs-to main {
+    prefix main;
+  }
+
+  revision 2026-03-20;
+
+  feature x-sub-f;
+  identity x-misc-id;
+
+  /* TODO does not work
+   * augment "/main:a-system" {
+   *  leaf user {
+   *    type string;
+   *  }
+   *}
+   */
+}


### PR DESCRIPTION
Your work based on `sid-extension` branch of `core-wg/pyang` introduced some regression. Luckily, the tests found that. I did trivial fix of `test1`. Please have a look on `test20`.

The test file `test/test_sid/test-20-expected-output.txt` is not that important. The much worst problem are the changes in the produced ieee802-dot1q-psfp@2020-07-07.sid.

To run the tests:
```sh
# in repository top diretory
ls
# output: 
# bin           CONTRIBUTING.md  dev-requirements.txt  env.sh  LICENSE   man          modules  README.md     requirements.txt  setup.cfg  test  tools          xslt
# CHANGELOG.md  CONTRIBUTORS     doc                   etc     Makefile  MANIFEST.in  pyang    RELEASE-INFO  schema            setup.py   TODO  uml-utilities
. env.sh
make -C test/test_sid
```

Alternatively, you can work in the `test/test_sid` directory
```sh
cd test/test_sid
make
```

To run specific test
```sh
make test20
```

If the test fails, there will be left produced output file (e.g. `ieee802-dot1q-psfp@2020-07-07.sid`). For some reason, your changes broke the tests:
```sh
diff -b test-20-expected-ieee802-dot1q-psfp@2020-07-07.sid ieee802-dot1q-psfp@2020-07-07.sid
```
Output:
```diff
47c47
<         "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-base-time/nanoseconds",
---
>         "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list",
53c53
<         "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-base-time/seconds",
---
>         "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry",
59c59
<         "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list",
---
>         "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-cycle-time",
65c65
<         "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry",
---
>         "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-cycle-time-extension",
71c71
<         "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/gate-state-value",
---
>         "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-change",
77c77
<         "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/index",
---
>         "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-change-error",
83c83
<         "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/interval-octet-max",
---
>         "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-change-time",
# ...
```

Your code must not stop emitting SID items for `.../ieee802-dot1q-psfp:admin-base-time/nanoseconds` etc.

Note that the `leaf nanoseconds` is defined in a YANG grouping. This might help you debug the issue.